### PR TITLE
Respect special pressure plates triggers

### DIFF
--- a/src/main/java/com/firemerald/additionalplacements/block/AdditionalPressurePlateBlock.java
+++ b/src/main/java/com/firemerald/additionalplacements/block/AdditionalPressurePlateBlock.java
@@ -1,15 +1,11 @@
 package com.firemerald.additionalplacements.block;
 
-import java.util.List;
-
 import com.firemerald.additionalplacements.block.interfaces.IPressurePlateBlock;
 
+import com.firemerald.additionalplacements.mixin.AccessorPressurePlate;
 import net.minecraft.core.BlockPos;
-import net.minecraft.world.entity.Entity;
-import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.PressurePlateBlock;
-import net.minecraft.world.phys.AABB;
 
 public class AdditionalPressurePlateBlock extends AdditionalBasePressurePlateBlock<PressurePlateBlock> implements IPressurePlateBlock<PressurePlateBlock>
 {
@@ -26,20 +22,6 @@ public class AdditionalPressurePlateBlock extends AdditionalBasePressurePlateBlo
 	@Override
 	protected int getSignalStrength(Level level, BlockPos pos)
 	{
-		AABB aabb = TOUCH_AABBS[level.getBlockState(pos).getValue(AdditionalBasePressurePlateBlock.PLACING).ordinal() - 1].move(pos);
-		List<? extends Entity> list;
-		switch (this.parentBlock.sensitivity)
-		{
-		case EVERYTHING:
-			list = level.getEntities(null, aabb);
-			break;
-		case MOBS:
-			list = level.getEntitiesOfClass(LivingEntity.class, aabb);
-			break;
-		default:
-			return 0;
-		}
-		if (!list.isEmpty()) for(Entity entity : list) if (!entity.isIgnoringBlockTriggers()) return 15;
-		return 0;
+		return ((AccessorPressurePlate) this.parentBlock).additional_placements_getSignalStrength(level, pos);
 	}
 }

--- a/src/main/java/com/firemerald/additionalplacements/mixin/AccessorPressurePlate.java
+++ b/src/main/java/com/firemerald/additionalplacements/mixin/AccessorPressurePlate.java
@@ -1,0 +1,14 @@
+package com.firemerald.additionalplacements.mixin;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.PressurePlateBlock;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Invoker;
+
+@Mixin(PressurePlateBlock.class)
+public interface AccessorPressurePlate
+{
+    @Invoker("getSignalStrength")
+    int additional_placements_getSignalStrength(Level pLevel, BlockPos pPos);
+}

--- a/src/main/resources/mixins.additionalplacements.json
+++ b/src/main/resources/mixins.additionalplacements.json
@@ -11,7 +11,8 @@
 		"MixinPressurePlateBlock",
 		"MixinSlabBlock",
 		"MixinStairBlock",
-		"MixinWeightedPressurePlateBlock"
+		"MixinWeightedPressurePlateBlock",
+		"AccessorPressurePlate"
 	],
 	"client": [
 		"MixinBlockModelShaper"


### PR DESCRIPTION
This PR makes vertical and ceiling pressure plates to respect the parent conditions for activation.

Whilst this also fixes a crash with quark [because they set the sensibility to null](https://github.com/VazkiiMods/Quark/issues/4602) it also makes it respect the rule of activation from mods like [player pressure plates](https://www.curseforge.com/minecraft/mc-mods/player-plates), since as for now, mobs can activate their pressure plates placed vertically for example.