### PR TITLE
1.20.4-fabric Mixin Injection Fix

### DIFF
--- a/src/main/java/com/firemerald/additionalplacements/mixin/MixinBlock.java
+++ b/src/main/java/com/firemerald/additionalplacements/mixin/MixinBlock.java
@@ -13,7 +13,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 public abstract class MixinBlock {
     @Inject(method = "getStateForPlacement", at = @At("RETURN"), cancellable = true)
     private void getStateForPlacement(BlockPlaceContext context, CallbackInfoReturnable<BlockState> ci) {
-        if ((Object) this instanceof IFloorBlock floorBlock) { // No CarpetBlock check needed
+        if ((Object) this instanceof IFloorBlock floorBlock) {
             if (floorBlock.enablePlacement(context.getClickedPos(), context.getLevel(), context.getClickedFace(), context.getPlayer())) {
                 ci.setReturnValue(floorBlock.getStateForPlacementImpl(context, ci.getReturnValue()));
             }

--- a/src/main/java/com/firemerald/additionalplacements/mixin/MixinBlock.java
+++ b/src/main/java/com/firemerald/additionalplacements/mixin/MixinBlock.java
@@ -1,0 +1,22 @@
+package com.firemerald.additionalplacements.mixin;
+
+import com.firemerald.additionalplacements.block.interfaces.IFloorBlock;
+import net.minecraft.world.item.context.BlockPlaceContext;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockState;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(Block.class)
+public abstract class MixinBlock {
+    @Inject(method = "getStateForPlacement", at = @At("RETURN"), cancellable = true)
+    private void getStateForPlacement(BlockPlaceContext context, CallbackInfoReturnable<BlockState> ci) {
+        if ((Object) this instanceof IFloorBlock floorBlock) { // No CarpetBlock check needed
+            if (floorBlock.enablePlacement(context.getClickedPos(), context.getLevel(), context.getClickedFace(), context.getPlayer())) {
+                ci.setReturnValue(floorBlock.getStateForPlacementImpl(context, ci.getReturnValue()));
+            }
+        }
+    }
+}

--- a/src/main/java/com/firemerald/additionalplacements/mixin/MixinBlockBehaviour.java
+++ b/src/main/java/com/firemerald/additionalplacements/mixin/MixinBlockBehaviour.java
@@ -27,4 +27,3 @@ public abstract class MixinBlockBehaviour {
         }
     }
 }
-

--- a/src/main/java/com/firemerald/additionalplacements/mixin/MixinBlockBehaviour.java
+++ b/src/main/java/com/firemerald/additionalplacements/mixin/MixinBlockBehaviour.java
@@ -1,0 +1,30 @@
+package com.firemerald.additionalplacements.mixin;
+
+import com.firemerald.additionalplacements.block.interfaces.IFloorBlock;
+import net.minecraft.world.level.block.Mirror;
+import net.minecraft.world.level.block.Rotation;
+import net.minecraft.world.level.block.state.BlockBehaviour;
+import net.minecraft.world.level.block.state.BlockState;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(BlockBehaviour.class)
+public abstract class MixinBlockBehaviour {
+
+    @Inject(method = "rotate", at = @At("HEAD"), cancellable = true)
+    private void rotate(BlockState blockState, Rotation rotation, CallbackInfoReturnable<BlockState> ci) {
+        if ((Object) this instanceof IFloorBlock floorBlock && floorBlock.hasAdditionalStates()) {
+            ci.setReturnValue(floorBlock.rotateImpl(blockState, rotation));
+        }
+    }
+
+    @Inject(method = "mirror", at = @At("HEAD"), cancellable = true)
+    private void mirror(BlockState blockState, Mirror mirror, CallbackInfoReturnable<BlockState> ci) {
+        if ((Object) this instanceof IFloorBlock floorBlock && floorBlock.hasAdditionalStates()) {
+            ci.setReturnValue(floorBlock.mirrorImpl(blockState, mirror));
+        }
+    }
+}
+

--- a/src/main/java/com/firemerald/additionalplacements/mixin/MixinCarpetBlock.java
+++ b/src/main/java/com/firemerald/additionalplacements/mixin/MixinCarpetBlock.java
@@ -1,15 +1,7 @@
 package com.firemerald.additionalplacements.mixin;
 
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Unique;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Desc;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-
 import com.firemerald.additionalplacements.block.AdditionalCarpetBlock;
 import com.firemerald.additionalplacements.block.interfaces.ICarpetBlock.IVanillaCarpetBlock;
-
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.item.context.BlockPlaceContext;
@@ -19,6 +11,8 @@ import net.minecraft.world.level.block.CarpetBlock;
 import net.minecraft.world.level.block.Mirror;
 import net.minecraft.world.level.block.Rotation;
 import net.minecraft.world.level.block.state.BlockState;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 
 @Mixin(CarpetBlock.class)
 public abstract class MixinCarpetBlock extends Block implements IVanillaCarpetBlock
@@ -77,15 +71,6 @@ public abstract class MixinCarpetBlock extends Block implements IVanillaCarpetBl
 		return currentState.is(carpet) ? currentState : carpet.copyProperties(currentState, carpet.defaultBlockState());
 	}
 
-	@Inject(at = @At("RETURN"), remap = false, cancellable = true, target = {
-			@Desc(value = "getStateForPlacement", ret = BlockState.class, args = {BlockPlaceContext.class}),
-			@Desc(value = "m_5573_", ret = BlockState.class, args = {BlockPlaceContext.class})
-	})
-	private void getStateForPlacement(BlockPlaceContext context, CallbackInfoReturnable<BlockState> ci)
-	{
-		if (this.hasAdditionalStates() && enablePlacement(context.getClickedPos(), context.getLevel(), context.getClickedFace(), context.getPlayer())) ci.setReturnValue(getStateForPlacementImpl(context, ci.getReturnValue()));
-	}
-
 	@Override
 	@Unique(silent = true)
 	public BlockState getStateForPlacement(BlockPlaceContext context)
@@ -95,15 +80,6 @@ public abstract class MixinCarpetBlock extends Block implements IVanillaCarpetBl
 		else return superRet;
 	}
 
-	@Inject(at = @At("HEAD"), remap = false, cancellable = true, target = {
-			@Desc(value = "rotate", ret = BlockState.class, args = {BlockState.class, Rotation.class}),
-			@Desc(value = "m_6843_", ret = BlockState.class, args = {BlockState.class, Rotation.class})
-	})
-	private void rotate(BlockState blockState, Rotation rotation, CallbackInfoReturnable<BlockState> ci)
-	{
-		if (this.hasAdditionalStates()) ci.setReturnValue(rotateImpl(blockState, rotation));
-	}
-
 	@Override
 	@Unique(silent = true)
 	@SuppressWarnings("deprecation")
@@ -111,15 +87,6 @@ public abstract class MixinCarpetBlock extends Block implements IVanillaCarpetBl
 	{
 		if (this.hasAdditionalStates()) return rotateImpl(blockState, rotation);
 		else return super.rotate(blockState, rotation);
-	}
-
-	@Inject(at = @At("HEAD"), remap = false, cancellable = true, target = {
-			@Desc(value = "mirror", ret = BlockState.class, args = {BlockState.class, Mirror.class}),
-			@Desc(value = "m_6943_", ret = BlockState.class, args = {BlockState.class, Mirror.class})
-	})
-	private void mirror(BlockState blockState, Mirror mirror, CallbackInfoReturnable<BlockState> ci)
-	{
-		if (this.hasAdditionalStates()) ci.setReturnValue(mirrorImpl(blockState, mirror));
 	}
 
 	@Override

--- a/src/main/java/com/firemerald/additionalplacements/mixin/MixinPressurePlateBlock.java
+++ b/src/main/java/com/firemerald/additionalplacements/mixin/MixinPressurePlateBlock.java
@@ -1,15 +1,7 @@
 package com.firemerald.additionalplacements.mixin;
 
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Unique;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Desc;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-
 import com.firemerald.additionalplacements.block.AdditionalPressurePlateBlock;
 import com.firemerald.additionalplacements.block.interfaces.IPressurePlateBlock.IVanillaPressurePlateBlock;
-
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.item.context.BlockPlaceContext;
@@ -19,6 +11,8 @@ import net.minecraft.world.level.block.Mirror;
 import net.minecraft.world.level.block.PressurePlateBlock;
 import net.minecraft.world.level.block.Rotation;
 import net.minecraft.world.level.block.state.BlockState;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 
 @Mixin(PressurePlateBlock.class)
 public abstract class MixinPressurePlateBlock extends Block implements IVanillaPressurePlateBlock
@@ -77,15 +71,6 @@ public abstract class MixinPressurePlateBlock extends Block implements IVanillaP
 		return currentState.is(plate) ? currentState : plate.copyProperties(currentState, plate.defaultBlockState());
 	}
 
-	@Inject(at = @At("RETURN"), remap = false, cancellable = true, target = {
-			@Desc(value = "getStateForPlacement", ret = BlockState.class, args = {BlockPlaceContext.class}),
-			@Desc(value = "m_5573_", ret = BlockState.class, args = {BlockPlaceContext.class})
-	})
-	private void getStateForPlacement(BlockPlaceContext context, CallbackInfoReturnable<BlockState> ci)
-	{
-		if (this.hasAdditionalStates() && enablePlacement(context.getClickedPos(), context.getLevel(), context.getClickedFace(), context.getPlayer())) ci.setReturnValue(getStateForPlacementImpl(context, ci.getReturnValue()));
-	}
-
 	@Override
 	@Unique(silent = true)
 	public BlockState getStateForPlacement(BlockPlaceContext context)
@@ -95,15 +80,6 @@ public abstract class MixinPressurePlateBlock extends Block implements IVanillaP
 		else return superRet;
 	}
 
-	@Inject(at = @At("HEAD"), remap = false, cancellable = true, target = {
-			@Desc(value = "rotate", ret = BlockState.class, args = {BlockState.class, Rotation.class}),
-			@Desc(value = "m_6843_", ret = BlockState.class, args = {BlockState.class, Rotation.class})
-	})
-	private void rotate(BlockState blockState, Rotation rotation, CallbackInfoReturnable<BlockState> ci)
-	{
-		if (this.hasAdditionalStates()) ci.setReturnValue(rotateImpl(blockState, rotation));
-	}
-
 	@Override
 	@Unique(silent = true)
 	@SuppressWarnings("deprecation")
@@ -111,16 +87,6 @@ public abstract class MixinPressurePlateBlock extends Block implements IVanillaP
 	{
 		if (this.hasAdditionalStates()) return rotateImpl(blockState, rotation);
 		else return super.rotate(blockState, rotation);
-	}
-
-
-	@Inject(at = @At("HEAD"), remap = false, cancellable = true, target = {
-			@Desc(value = "mirror", ret = BlockState.class, args = {BlockState.class, Mirror.class}),
-			@Desc(value = "m_6943_", ret = BlockState.class, args = {BlockState.class, Mirror.class})
-	})
-	private void mirror(BlockState blockState, Mirror mirror, CallbackInfoReturnable<BlockState> ci)
-	{
-		if (this.hasAdditionalStates()) ci.setReturnValue(mirrorImpl(blockState, mirror));
 	}
 
 	@Override

--- a/src/main/java/com/firemerald/additionalplacements/mixin/MixinSlabBlock.java
+++ b/src/main/java/com/firemerald/additionalplacements/mixin/MixinSlabBlock.java
@@ -1,15 +1,7 @@
 package com.firemerald.additionalplacements.mixin;
 
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Unique;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Desc;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-
 import com.firemerald.additionalplacements.block.VerticalSlabBlock;
 import com.firemerald.additionalplacements.block.interfaces.ISlabBlock.IVanillaSlabBlock;
-
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.item.context.BlockPlaceContext;
@@ -19,6 +11,11 @@ import net.minecraft.world.level.block.Mirror;
 import net.minecraft.world.level.block.Rotation;
 import net.minecraft.world.level.block.SlabBlock;
 import net.minecraft.world.level.block.state.BlockState;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(SlabBlock.class)
 public abstract class MixinSlabBlock extends Block implements IVanillaSlabBlock
@@ -88,15 +85,6 @@ public abstract class MixinSlabBlock extends Block implements IVanillaSlabBlock
 		if (this.hasAdditionalStates() && enablePlacement(context.getClickedPos(), context.getLevel(), context.getClickedFace(), context.getPlayer())) ci.setReturnValue(getStateForPlacementImpl(context, ci.getReturnValue()));
 	}
 
-	@Inject(at = @At("HEAD"), remap = false, cancellable = true, target = {
-			@Desc(value = "rotate", ret = BlockState.class, args = {BlockState.class, Rotation.class}),
-			@Desc(value = "m_6843_", ret = BlockState.class, args = {BlockState.class, Rotation.class})
-			})
-	private void rotate(BlockState blockState, Rotation rotation, CallbackInfoReturnable<BlockState> ci)
-	{
-		if (this.hasAdditionalStates()) ci.setReturnValue(rotateImpl(blockState, rotation));
-	}
-
 	@Override
 	@Unique(silent = true)
 	@SuppressWarnings("deprecation")
@@ -104,16 +92,6 @@ public abstract class MixinSlabBlock extends Block implements IVanillaSlabBlock
 	{
 		if (this.hasAdditionalStates()) return rotateImpl(blockState, rotation);
 		else return super.rotate(blockState, rotation);
-	}
-
-
-	@Inject(at = @At("HEAD"), remap = false, cancellable = true, target = {
-			@Desc(value = "mirror", ret = BlockState.class, args = {BlockState.class, Mirror.class}),
-			@Desc(value = "m_6943_", ret = BlockState.class, args = {BlockState.class, Mirror.class})
-	})
-	private void mirror(BlockState blockState, Mirror mirror, CallbackInfoReturnable<BlockState> ci)
-	{
-		if (this.hasAdditionalStates()) ci.setReturnValue(mirrorImpl(blockState, mirror));
 	}
 
 	@Override

--- a/src/main/java/com/firemerald/additionalplacements/mixin/MixinWeightedPressurePlateBlock.java
+++ b/src/main/java/com/firemerald/additionalplacements/mixin/MixinWeightedPressurePlateBlock.java
@@ -1,15 +1,7 @@
 package com.firemerald.additionalplacements.mixin;
 
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Unique;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Desc;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-
 import com.firemerald.additionalplacements.block.AdditionalWeightedPressurePlateBlock;
 import com.firemerald.additionalplacements.block.interfaces.IWeightedPressurePlateBlock.IVanillaWeightedPressurePlateBlock;
-
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.item.context.BlockPlaceContext;
@@ -19,6 +11,8 @@ import net.minecraft.world.level.block.Mirror;
 import net.minecraft.world.level.block.Rotation;
 import net.minecraft.world.level.block.WeightedPressurePlateBlock;
 import net.minecraft.world.level.block.state.BlockState;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 
 @Mixin(WeightedPressurePlateBlock.class)
 public abstract class MixinWeightedPressurePlateBlock extends Block implements IVanillaWeightedPressurePlateBlock
@@ -77,15 +71,6 @@ public abstract class MixinWeightedPressurePlateBlock extends Block implements I
 		return currentState.is(plate) ? currentState : plate.copyProperties(currentState, plate.defaultBlockState());
 	}
 
-	@Inject(at = @At("RETURN"), remap = false, cancellable = true, target = {
-			@Desc(value = "getStateForPlacement", ret = BlockState.class, args = {BlockPlaceContext.class}),
-			@Desc(value = "m_5573_", ret = BlockState.class, args = {BlockPlaceContext.class})
-	})
-	private void getStateForPlacement(BlockPlaceContext context, CallbackInfoReturnable<BlockState> ci)
-	{
-		if (this.hasAdditionalStates() && enablePlacement(context.getClickedPos(), context.getLevel(), context.getClickedFace(), context.getPlayer())) ci.setReturnValue(getStateForPlacementImpl(context, ci.getReturnValue()));
-	}
-
 	@Override
 	@Unique(silent = true)
 	public BlockState getStateForPlacement(BlockPlaceContext context)
@@ -95,15 +80,6 @@ public abstract class MixinWeightedPressurePlateBlock extends Block implements I
 		else return superRet;
 	}
 
-	@Inject(at = @At("HEAD"), remap = false, cancellable = true, target = {
-			@Desc(value = "rotate", ret = BlockState.class, args = {BlockState.class, Rotation.class}),
-			@Desc(value = "m_6843_", ret = BlockState.class, args = {BlockState.class, Rotation.class})
-			})
-	private void rotate(BlockState blockState, Rotation rotation, CallbackInfoReturnable<BlockState> ci)
-	{
-		if (this.hasAdditionalStates()) ci.setReturnValue(rotateImpl(blockState, rotation));
-	}
-
 	@Override
 	@Unique(silent = true)
 	@SuppressWarnings("deprecation")
@@ -111,16 +87,6 @@ public abstract class MixinWeightedPressurePlateBlock extends Block implements I
 	{
 		if (this.hasAdditionalStates()) return rotateImpl(blockState, rotation);
 		else return super.rotate(blockState, rotation);
-	}
-
-
-	@Inject(at = @At("HEAD"), remap = false, cancellable = true, target = {
-			@Desc(value = "mirror", ret = BlockState.class, args = {BlockState.class, Mirror.class}),
-			@Desc(value = "m_6943_", ret = BlockState.class, args = {BlockState.class, Mirror.class})
-	})
-	private void mirror(BlockState blockState, Mirror mirror, CallbackInfoReturnable<BlockState> ci)
-	{
-		if (this.hasAdditionalStates()) ci.setReturnValue(mirrorImpl(blockState, mirror));
 	}
 
 	@Override

--- a/src/main/resources/mixins.additionalplacements.json
+++ b/src/main/resources/mixins.additionalplacements.json
@@ -1,25 +1,27 @@
 {
-	"required": true,
-	"package": "com.firemerald.additionalplacements.mixin",
-	"compatibilityLevel": "JAVA_17",
-	"mixins": [
-		"MixinBasePressurePlateBlock",
-		"MixinCarpetBlock",
-		"MixinPressurePlateBlock",
-		"MixinSlabBlock",
-		"MixinStairBlock",
-		"MixinWeightedPressurePlateBlock",
-		"MixinPlayer",
-		"MixinServerPlayer",
-		"MixinChunkStorage"
-	],
-	"client": [
-		"MixinLocalPlayer",
-		"MixinModelBakery",
-		"MixinVertexFormat"
-	],
-	"minVersion": "0.8",
-	"injectors": {
-		"defaultRequire": 1
+  "required": true,
+  "package": "com.firemerald.additionalplacements.mixin",
+  "compatibilityLevel": "JAVA_17",
+  "mixins": [
+    "MixinBasePressurePlateBlock",
+    "MixinBlock",
+    "MixinBlockBehaviour",
+    "MixinCarpetBlock",
+    "MixinChunkStorage",
+    "MixinPlayer",
+    "MixinPressurePlateBlock",
+    "MixinServerPlayer",
+    "MixinSlabBlock",
+    "MixinStairBlock",
+    "MixinWeightedPressurePlateBlock"
+  ],
+  "client": [
+    "MixinLocalPlayer",
+    "MixinModelBakery",
+    "MixinVertexFormat"
+  ],
+  "minVersion": "0.8",
+  "injectors": {
+    "defaultRequire": 1
 	}
 }


### PR DESCRIPTION
Taken the parent method "@ Injects" out of the child classes MixinSlabBlock/CarpetBlock/PressurePlateBlock/WeightPressurePlateBlock, and moved them into parent Mixin classes MixinBlock, and MixinBlockBehaviour as game would crash without these changes.

Mixin has issues when trying to "@ Inject" into parent classes.

I've only made the change to this version (1.20.4-Fabric) as it was the one I was playing in, but I imagine this fix will need to be applied to all future and possible several past Fabric versions, ref #117 & #118 